### PR TITLE
Modificada função de busca do estado/UF (iso_code)

### DIFF
--- a/moipv2/controllers/front/authorization.php
+++ b/moipv2/controllers/front/authorization.php
@@ -456,8 +456,8 @@ class Moipv2AuthorizationModuleFrontController extends ModuleFrontController
              // FIM - definição do atributo para o documento cpf...  altere caso necessário para o seu atributo.
 
           
-            $prestashopState = $this->getPrestaShopState($address->id_state);
-            $addressUF = $prestashopState['iso_code'];
+            $prestashopState = new State($address->id_state);
+            $addressUF = $prestashopState-> iso_code;
             $array_order = array(
                             "ownId" => (int)$this->context->cart->id,
                             "amount" => array(


### PR DESCRIPTION
- Alterada a função para função nativa do prestashop para retornar iso_code do UF.
- Não sei se a função é usada em algum outro lugar, se não poderá ser removida.